### PR TITLE
Actualizo README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Los scrapers descargan automáticamente la información, portada, sinopsis, repa
 1. Descargar la imágen preconfigurada [**Mediacenter-AikonCWD-v6.img**](https://github.com/aikoncwd/aikoncwd-rpi-mediacenter/raw/master/Mediacenter-AikonCWD-v6.torrent)
 2. Grabar la imagen en tu tarjeta **microSD**:
   - **Windows**: Utilizar el programa [win32diskimager](https://sourceforge.net/projects/win32diskimager/)
-  - **Linux/Mac**: `sudo pv Mediacenter-AikonCWD-v6.img | dd of=disk2s1 bs=4m && sync`
+  - **Linux/Mac**: `sudo pv Mediacenter-AikonCWD-v6.img | sudo dd of=disk2s1 bs=4M && sync`
 3. Introduce tu **microSD** con la imagen grabada en tu Raspberry
 4. Enchufa el **cable de alimentación**
 5. La Raspberry se encenderá, aparecerá la imágen inicial de *garlic-dog*


### PR DESCRIPTION
Corrijo 2 fallos (que al menos yo me he encontrado). 
1. si `pv` necesita permisos sudo, `dd` también necesita permisos sudo. 
2. la magnitud para `dd` hay que ponerla en mayúscula (al menos en Fedora 24 con `dd` versión 8.25)